### PR TITLE
Remove conduit

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -3,14 +3,11 @@
 
 module Main where
 
-import Control.Monad.Trans.Resource            (MonadThrow)
 import Criterion.Main
-import Data.Conduit
 import Data.Word
 import Foreign
 import HaskellWorks.Data.BalancedParens.Simple
 import HaskellWorks.Data.Bits.BitShown
-import HaskellWorks.Data.Conduit.List
 import HaskellWorks.Data.FromByteString
 import HaskellWorks.Data.Xml.Conduit
 import HaskellWorks.Data.Xml.Conduit.Blank
@@ -30,11 +27,11 @@ setupEnvXml filepath = do
 loadXml :: BS.ByteString -> XmlCursor BS.ByteString (BitShown (DVS.Vector Word64)) (SimpleBalancedParens (DVS.Vector Word64))
 loadXml bs = fromByteString bs :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word64)) (SimpleBalancedParens (DVS.Vector Word64))
 
-xmlToInterestBits3 :: MonadThrow m => Conduit BS.ByteString m BS.ByteString
-xmlToInterestBits3 = blankXml .| blankedXmlToInterestBits
+xmlToInterestBits3 :: [BS.ByteString] -> [BS.ByteString]
+xmlToInterestBits3 = blankedXmlToInterestBits . blankXml
 
-runCon :: Conduit i [] BS.ByteString -> i -> BS.ByteString
-runCon con bs = BS.concat $ runListConduit con [bs]
+runCon :: ([i] -> [BS.ByteString]) -> i -> BS.ByteString
+runCon con bs = BS.concat $ con [bs]
 
 benchRankXmlCatalogConduits :: [Benchmark]
 benchRankXmlCatalogConduits =

--- a/hw-xml.cabal
+++ b/hw-xml.cabal
@@ -31,7 +31,6 @@ common array                      { build-depends: array                      >=
 common attoparsec                 { build-depends: attoparsec                 >= 0.13.2.2   && < 0.14   }
 common bytestring                 { build-depends: bytestring                 >= 0.10.8.2   && < 0.11   }
 common cereal                     { build-depends: cereal                     >= 0.5.8.1    && < 0.6    }
-common conduit                    { build-depends: conduit                    >= 1.3.1.1    && < 1.4    }
 common containers                 { build-depends: containers                 >= 0.6.2.1    && < 0.7    }
 common criterion                  { build-depends: criterion                  >= 1.5.5.0    && < 1.6    }
 common deepseq                    { build-depends: deepseq                    >= 1.4.3.0    && < 1.5    }
@@ -40,7 +39,6 @@ common hedgehog                   { build-depends: hedgehog                   >=
 common hspec                      { build-depends: hspec                      >= 2.5        && < 3.0    }
 common hw-balancedparens          { build-depends: hw-balancedparens          >= 0.3.0.0    && < 0.4    }
 common hw-bits                    { build-depends: hw-bits                    >= 0.7.0.6    && < 0.8    }
-common hw-conduit                 { build-depends: hw-conduit                 >= 0.2.0.5    && < 0.3    }
 common hw-hspec-hedgehog          { build-depends: hw-hspec-hedgehog          >= 0.1        && < 0.2    }
 common hw-parser                  { build-depends: hw-parser                  >= 0.1.0.1    && < 0.2    }
 common hw-prim                    { build-depends: hw-prim                    >= 0.6.2.28   && < 0.7    }
@@ -65,13 +63,11 @@ library
           , base
           , bytestring
           , cereal
-          , conduit
           , containers
           , deepseq
           , ghc-prim
           , hw-balancedparens
           , hw-bits
-          , hw-conduit
           , hw-parser
           , hw-prim
           , hw-rankselect
@@ -136,11 +132,9 @@ test-suite hw-xml-test
           , attoparsec
           , base
           , bytestring
-          , conduit
           , hspec
           , hw-balancedparens
           , hw-bits
-          , hw-conduit
           , hw-prim
           , hw-rankselect
           , hw-rankselect-base
@@ -166,11 +160,9 @@ test-suite hw-xml-test
 benchmark bench
   import:   base, config
           , bytestring
-          , conduit
           , criterion
           , hw-balancedparens
           , hw-bits
-          , hw-conduit
           , hw-prim
           , mmap
           , resourcet

--- a/src/HaskellWorks/Data/Xml/Conduit.hs
+++ b/src/HaskellWorks/Data/Xml/Conduit.hs
@@ -4,7 +4,6 @@
 module HaskellWorks.Data.Xml.Conduit
   ( blankedXmlToInterestBits
   , byteStringToBits
-  , blankedXmlToBalancedParens
   , blankedXmlToBalancedParens2
   , compressWordAsBit
   , interestingWord8s
@@ -64,30 +63,6 @@ blankedXmlToInterestBits' rs = do
           else Just ( BS.foldr' (\b m -> (interestingWord8s ! b) .|. (m .<. 1)) 0 (BS.take 8 as)
                     , BS.drop 8 as
                     )
-
-blankedXmlToBalancedParens :: Monad m => ConduitT BS.ByteString Bool m ()
-blankedXmlToBalancedParens = do
-  mbs <- await
-  case mbs of
-    Just bs -> blankedXmlToBalancedParens' bs
-    Nothing -> return ()
-
-blankedXmlToBalancedParens' :: Monad m => BS.ByteString -> ConduitT BS.ByteString Bool m ()
-blankedXmlToBalancedParens' bs = case BS.uncons bs of
-  Just (c, cs) -> do
-    case c of
-      d | d == _less         -> yield True
-      d | d == _greater      -> yield False
-      d | d == _bracketleft  -> yield True
-      d | d == _bracketright -> yield False
-      d | d == _parenleft    -> yield True
-      d | d == _parenright   -> yield False
-      d | d == _a            -> yield True >> yield False
-      d | d == _v            -> yield True >> yield False
-      d | d == _t            -> yield True >> yield False
-      _                      -> return ()
-    blankedXmlToBalancedParens' cs
-  Nothing -> return ()
 
 repartitionMod8 :: BS.ByteString -> BS.ByteString -> (BS.ByteString, BS.ByteString)
 repartitionMod8 aBS bBS = (BS.take cLen abBS, BS.drop cLen abBS)

--- a/src/HaskellWorks/Data/Xml/Conduit.hs
+++ b/src/HaskellWorks/Data/Xml/Conduit.hs
@@ -10,10 +10,8 @@ module HaskellWorks.Data.Xml.Conduit
   , isInterestingWord8
   ) where
 
-import Control.Monad
 import Data.Array.Unboxed             as A
 import Data.ByteString                as BS
-import Data.Conduit
 import Data.Word
 import Data.Word8
 import HaskellWorks.Data.Bits.BitWise
@@ -38,25 +36,22 @@ isInterestingWord8 :: Word8 -> Word8
 isInterestingWord8 b = interestingWord8s ! b
 {-# INLINABLE isInterestingWord8 #-}
 
-blankedXmlToInterestBits :: Monad m => ConduitT BS.ByteString BS.ByteString m ()
+blankedXmlToInterestBits :: [BS.ByteString] -> [BS.ByteString]
 blankedXmlToInterestBits = blankedXmlToInterestBits' ""
 
-blankedXmlToInterestBits' :: Monad m => BS.ByteString -> ConduitT BS.ByteString BS.ByteString m ()
-blankedXmlToInterestBits' rs = do
-  mbs <- await
-  case mbs of
-    Just bs -> do
-      let cs = if BS.length rs /= 0 then BS.concat [rs, bs] else bs
-      let lencs = BS.length cs
-      let q = lencs `quot` 8
-      let (ds, es) = BS.splitAt (q * 8) cs
-      let (fs, _) = BS.unfoldrN q gen ds
-      yield fs
-      blankedXmlToInterestBits' es
-    Nothing -> do
-      let lenrs = BS.length rs
-      let q = lenrs + 7 `quot` 8
-      yield (fst (BS.unfoldrN q gen rs))
+blankedXmlToInterestBits' :: BS.ByteString -> [BS.ByteString] -> [BS.ByteString]
+blankedXmlToInterestBits' rs is = case is of
+  (bs:bss) -> do
+    let cs = if BS.length rs /= 0 then BS.concat [rs, bs] else bs
+    let lencs = BS.length cs
+    let q = lencs `quot` 8
+    let (ds, es) = BS.splitAt (q * 8) cs
+    let (fs, _) = BS.unfoldrN q gen ds
+    fs:blankedXmlToInterestBits' es bss
+  [] -> do
+    let lenrs = BS.length rs
+    let q = lenrs + 7 `quot` 8
+    [fst (BS.unfoldrN q gen rs)]
   where gen :: ByteString -> Maybe (Word8, ByteString)
         gen as = if BS.length as == 0
           then Nothing
@@ -70,21 +65,18 @@ repartitionMod8 aBS bBS = (BS.take cLen abBS, BS.drop cLen abBS)
         abLen = BS.length abBS
         cLen = (abLen `div` 8) * 8
 
-compressWordAsBit :: Monad m => ConduitT BS.ByteString BS.ByteString m ()
+compressWordAsBit :: [BS.ByteString] -> [BS.ByteString]
 compressWordAsBit = compressWordAsBit' BS.empty
 
-compressWordAsBit' :: Monad m => BS.ByteString -> ConduitT BS.ByteString BS.ByteString m ()
-compressWordAsBit' aBS = do
-  mbBS <- await
-  case mbBS of
-    Just bBS -> do
-      let (cBS, dBS) = repartitionMod8 aBS bBS
-      let (cs, _) = BS.unfoldrN (BS.length cBS + 7 `div` 8) gen cBS
-      yield cs
-      compressWordAsBit' dBS
-    Nothing -> do
-      let (cs, _) = BS.unfoldrN (BS.length aBS + 7 `div` 8) gen aBS
-      yield cs
+compressWordAsBit' :: BS.ByteString -> [BS.ByteString] -> [BS.ByteString]
+compressWordAsBit' aBS iBS = case iBS of
+  (bBS:bBSs) -> do
+    let (cBS, dBS) = repartitionMod8 aBS bBS
+    let (cs, _) = BS.unfoldrN (BS.length cBS + 7 `div` 8) gen cBS
+    cs:compressWordAsBit' dBS bBSs
+  [] -> do
+    let (cs, _) = BS.unfoldrN (BS.length aBS + 7 `div` 8) gen aBS
+    [cs]
   where gen :: ByteString -> Maybe (Word8, ByteString)
         gen xs = if BS.length xs == 0
           then Nothing
@@ -92,15 +84,12 @@ compressWordAsBit' aBS = do
                     , BS.drop 8 xs
                     )
 
-blankedXmlToBalancedParens2 :: Monad m => ConduitT BS.ByteString BS.ByteString m ()
-blankedXmlToBalancedParens2 = do
-  mbs <- await
-  case mbs of
-    Just bs -> do
-      let (cs, _) = BS.unfoldrN (BS.length bs * 2) gen (Nothing, bs)
-      yield cs
-      blankedXmlToBalancedParens2
-    Nothing -> return ()
+blankedXmlToBalancedParens2 :: [BS.ByteString] -> [BS.ByteString]
+blankedXmlToBalancedParens2 is = case is of
+  (bs:bss) -> do
+    let (cs, _) = BS.unfoldrN (BS.length bs * 2) gen (Nothing, bs)
+    cs:blankedXmlToBalancedParens2 bss
+  [] -> []
   where gen :: (Maybe Bool, ByteString) -> Maybe (Word8, (Maybe Bool, ByteString))
         gen (Just True  , bs) = Just (0xFF, (Nothing, bs))
         gen (Just False , bs) = Just (0x00, (Nothing, bs))
@@ -127,23 +116,22 @@ balancedParensOf c = case c of
     d | d == _v            -> MiniTF
     _                      -> MiniN
 
-yieldBitsOfWord8 :: Monad m => Word8 -> ConduitT BS.ByteString Bool m ()
-yieldBitsOfWord8 w = do
-  yield ((w .&. BITS.bit 0) /= 0)
-  yield ((w .&. BITS.bit 1) /= 0)
-  yield ((w .&. BITS.bit 2) /= 0)
-  yield ((w .&. BITS.bit 3) /= 0)
-  yield ((w .&. BITS.bit 4) /= 0)
-  yield ((w .&. BITS.bit 5) /= 0)
-  yield ((w .&. BITS.bit 6) /= 0)
-  yield ((w .&. BITS.bit 7) /= 0)
+yieldBitsOfWord8 :: Word8 -> [Bool]
+yieldBitsOfWord8 w =
+  [ (w .&. BITS.bit 0) /= 0
+  , (w .&. BITS.bit 1) /= 0
+  , (w .&. BITS.bit 2) /= 0
+  , (w .&. BITS.bit 3) /= 0
+  , (w .&. BITS.bit 4) /= 0
+  , (w .&. BITS.bit 5) /= 0
+  , (w .&. BITS.bit 6) /= 0
+  , (w .&. BITS.bit 7) /= 0
+  ]
 
-yieldBitsofWord8s :: Monad m => [Word8] -> ConduitT BS.ByteString Bool m ()
-yieldBitsofWord8s = P.foldr ((>>) . yieldBitsOfWord8) (return ())
+yieldBitsofWord8s :: [Word8] -> [Bool]
+yieldBitsofWord8s = P.foldr ((++) . yieldBitsOfWord8) []
 
-byteStringToBits :: Monad m => ConduitT BS.ByteString Bool m ()
-byteStringToBits = do
-  mbs <- await
-  case mbs of
-    Just bs -> yieldBitsofWord8s (BS.unpack bs) >> byteStringToBits
-    Nothing -> return ()
+byteStringToBits :: [BS.ByteString] -> [Bool]
+byteStringToBits is = case is of
+  (bs:bss) -> yieldBitsofWord8s (BS.unpack bs) ++ byteStringToBits bss
+  []       -> []

--- a/src/HaskellWorks/Data/Xml/Succinct/Cursor/BalancedParens.hs
+++ b/src/HaskellWorks/Data/Xml/Succinct/Cursor/BalancedParens.hs
@@ -9,10 +9,8 @@ module HaskellWorks.Data.Xml.Succinct.Cursor.BalancedParens
   ) where
 
 import Control.Applicative
-import Data.Conduit
 import Data.Word
 import HaskellWorks.Data.BalancedParens                 as BP
-import HaskellWorks.Data.Conduit.List
 import HaskellWorks.Data.Xml.Conduit
 import HaskellWorks.Data.Xml.Succinct.Cursor.BlankedXml
 
@@ -30,20 +28,20 @@ genBitWordsForever bs = BS.uncons bs <|> Just (0, bs)
 
 instance FromBlankedXml (XmlBalancedParens (SimpleBalancedParens (DVS.Vector Word8))) where
   fromBlankedXml bj    = XmlBalancedParens (SimpleBalancedParens (DVS.unsafeCast (DVS.unfoldrN newLen genBitWordsForever interestBS)))
-    where interestBS    = BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) (getBlankedXml bj))
+    where interestBS    = BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 (getBlankedXml bj)))
           newLen        = (BS.length interestBS + 7) `div` 8 * 8
 
 instance FromBlankedXml (XmlBalancedParens (SimpleBalancedParens (DVS.Vector Word16))) where
   fromBlankedXml bj    = XmlBalancedParens (SimpleBalancedParens (DVS.unsafeCast (DVS.unfoldrN newLen genBitWordsForever interestBS)))
-    where interestBS    = BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) (getBlankedXml bj))
+    where interestBS    = BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 (getBlankedXml bj)))
           newLen        = (BS.length interestBS + 7) `div` 8 * 8
 
 instance FromBlankedXml (XmlBalancedParens (SimpleBalancedParens (DVS.Vector Word32))) where
   fromBlankedXml bj    = XmlBalancedParens (SimpleBalancedParens (DVS.unsafeCast (DVS.unfoldrN newLen genBitWordsForever interestBS)))
-    where interestBS    = BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) (getBlankedXml bj))
+    where interestBS    = BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 (getBlankedXml bj)))
           newLen        = (BS.length interestBS + 7) `div` 8 * 8
 
 instance FromBlankedXml (XmlBalancedParens (SimpleBalancedParens (DVS.Vector Word64))) where
   fromBlankedXml bj    = XmlBalancedParens (SimpleBalancedParens (DVS.unsafeCast (DVS.unfoldrN newLen genBitWordsForever interestBS)))
-    where interestBS    = BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) (getBlankedXml bj))
+    where interestBS    = BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 (getBlankedXml bj)))
           newLen        = (BS.length interestBS + 7) `div` 8 * 8

--- a/src/HaskellWorks/Data/Xml/Succinct/Cursor/BalancedParens.hs
+++ b/src/HaskellWorks/Data/Xml/Succinct/Cursor/BalancedParens.hs
@@ -28,9 +28,6 @@ genBitWordsForever :: BS.ByteString -> Maybe (Word8, BS.ByteString)
 genBitWordsForever bs = BS.uncons bs <|> Just (0, bs)
 {-# INLINABLE genBitWordsForever #-}
 
-instance FromBlankedXml (XmlBalancedParens (SimpleBalancedParens [Bool])) where
-  fromBlankedXml (BlankedXml bj) = XmlBalancedParens (SimpleBalancedParens (runListConduit blankedXmlToBalancedParens bj))
-
 instance FromBlankedXml (XmlBalancedParens (SimpleBalancedParens (DVS.Vector Word8))) where
   fromBlankedXml bj    = XmlBalancedParens (SimpleBalancedParens (DVS.unsafeCast (DVS.unfoldrN newLen genBitWordsForever interestBS)))
     where interestBS    = BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) (getBlankedXml bj))

--- a/src/HaskellWorks/Data/Xml/Succinct/Cursor/BlankedXml.hs
+++ b/src/HaskellWorks/Data/Xml/Succinct/Cursor/BlankedXml.hs
@@ -6,7 +6,6 @@ module HaskellWorks.Data.Xml.Succinct.Cursor.BlankedXml
   ) where
 
 import HaskellWorks.Data.ByteString
-import HaskellWorks.Data.Conduit.List
 import HaskellWorks.Data.FromByteString
 import HaskellWorks.Data.Xml.Conduit.Blank
 
@@ -20,6 +19,5 @@ getBlankedXml (BlankedXml bs) = bs
 class FromBlankedXml a where
   fromBlankedXml :: BlankedXml -> a
 
-
 instance FromByteString BlankedXml where
-  fromByteString bs = BlankedXml (runListConduit blankXml (chunkedBy 4064 bs))
+  fromByteString bs = BlankedXml (blankXml (chunkedBy 4064 bs))

--- a/src/HaskellWorks/Data/Xml/Succinct/Cursor/InterestBits.hs
+++ b/src/HaskellWorks/Data/Xml/Succinct/Cursor/InterestBits.hs
@@ -14,7 +14,6 @@ import Control.Applicative
 import Data.ByteString.Internal
 import Data.Word
 import HaskellWorks.Data.Bits.BitShown
-import HaskellWorks.Data.Conduit.List
 import HaskellWorks.Data.FromByteString
 import HaskellWorks.Data.RankSelect.Poppy512
 import HaskellWorks.Data.Xml.Conduit
@@ -29,7 +28,7 @@ getXmlInterestBits :: XmlInterestBits a -> a
 getXmlInterestBits (XmlInterestBits a) = a
 
 blankedXmlBssToInterestBitsBs :: [ByteString] -> ByteString
-blankedXmlBssToInterestBitsBs bss = BS.concat $ runListConduit blankedXmlToInterestBits bss
+blankedXmlBssToInterestBitsBs bss = BS.concat $ blankedXmlToInterestBits bss
 
 genInterest :: ByteString -> Maybe (Word8, ByteString)
 genInterest = BS.uncons
@@ -38,7 +37,7 @@ genInterestForever :: ByteString -> Maybe (Word8, ByteString)
 genInterestForever bs = BS.uncons bs <|> Just (0, bs)
 
 instance FromBlankedXml (XmlInterestBits (BitShown [Bool])) where
-  fromBlankedXml = XmlInterestBits . fromByteString . BS.concat . runListConduit blankedXmlToInterestBits . getBlankedXml
+  fromBlankedXml = XmlInterestBits . fromByteString . BS.concat . blankedXmlToInterestBits . getBlankedXml
 
 instance FromBlankedXml (XmlInterestBits (BitShown BS.ByteString)) where
   fromBlankedXml = XmlInterestBits . BitShown . BS.unfoldr genInterest . blankedXmlBssToInterestBitsBs . getBlankedXml

--- a/src/HaskellWorks/Data/Xml/Succinct/Cursor/Internal.hs
+++ b/src/HaskellWorks/Data/Xml/Succinct/Cursor/Internal.hs
@@ -10,7 +10,7 @@ module HaskellWorks.Data.Xml.Succinct.Cursor.Internal
   , xmlCursorPos
   ) where
 
-import Control.DeepSeq                                    (NFData(..))
+import Control.DeepSeq                                    (NFData (..))
 import Data.ByteString.Internal                           as BSI
 import Data.String
 import Data.Word
@@ -55,17 +55,6 @@ instance  (FromBlankedXml (XmlInterestBits a), FromBlankedXml (CBP.XmlBalancedPa
     }
     where blankedXml :: BlankedXml
           blankedXml = fromByteString bs
-
-instance IsString (XmlCursor String (BitShown [Bool]) (BP.SimpleBalancedParens [Bool])) where
-  fromString :: String -> XmlCursor String (BitShown [Bool]) (BP.SimpleBalancedParens [Bool])
-  fromString s = XmlCursor
-    { cursorText      = s
-    , cursorRank      = 1
-    , interests       = getXmlInterestBits (fromBlankedXml blankedXml)
-    , balancedParens  = CBP.getXmlBalancedParens (fromBlankedXml blankedXml)
-    }
-    where blankedXml :: BlankedXml
-          blankedXml = fromByteString (BSC.pack s)
 
 instance IsString (XmlCursor BS.ByteString (BitShown (DVS.Vector Word8)) (BP.SimpleBalancedParens (DVS.Vector Word8))) where
   fromString = fromByteString . BSC.pack

--- a/test/HaskellWorks/Data/Xml/Conduit/BlankSpec.hs
+++ b/test/HaskellWorks/Data/Xml/Conduit/BlankSpec.hs
@@ -6,7 +6,6 @@ module HaskellWorks.Data.Xml.Conduit.BlankSpec (spec) where
 import Data.Char
 import Data.Monoid
 import HaskellWorks.Data.ByteString
-import HaskellWorks.Data.Conduit.List
 import HaskellWorks.Data.Xml.Conduit.Blank
 import Test.Hspec
 import Test.QuickCheck
@@ -19,7 +18,7 @@ import qualified Data.ByteString as BS
 whenBlankedXmlShouldBe :: BS.ByteString -> BS.ByteString -> Spec
 whenBlankedXmlShouldBe original expected = do
   it (show original <> " when blanked xml should be " <> show expected) $ do
-    BS.concat (runListConduit blankXml [original]) `shouldBe` expected
+    BS.concat (blankXml [original]) `shouldBe` expected
 
 repeatBS :: Int -> BS.ByteString -> BS.ByteString
 repeatBS n bs | n > 0   = bs <> repeatBS (n - 1) bs
@@ -73,12 +72,12 @@ spec = describe "HaskellWorks.Data.Xml.Conduit.BlankSpec" $ do
     let inputOriginalSuffix = "\n  </attack>\n  <attack></attack>\n  <attack></attack>\n  <attack></attack>\n  <attack></attack>\n</statistics>\n"
     let inputOriginal = inputOriginalPrefix <> inputOriginalSuffix
     let inputOriginalChunked = chunkedBy 16 inputOriginal
-    let inputOriginalBlanked = runListConduit blankXml inputOriginalChunked
+    let inputOriginalBlanked = blankXml inputOriginalChunked
 
     forAll (choose (0, 16)) $ \(n :: Int) -> do
       let inputShifted = inputOriginalPrefix <> repeatBS n " " <> inputOriginalSuffix
       let inputShiftedChunked = chunkedBy 16 inputShifted
-      let inputShiftedBlanked = runListConduit blankXml inputShiftedChunked
+      let inputShiftedBlanked = blankXml inputShiftedChunked
 
       noSpaces (BS.concat inputShiftedBlanked) `shouldBe` noSpaces (BS.concat inputOriginalBlanked)
   it "Can blank across chunk boundaries with auto-close tags" $ do
@@ -86,12 +85,12 @@ spec = describe "HaskellWorks.Data.Xml.Conduit.BlankSpec" $ do
     let inputOriginalSuffix = "<inner/></attack><attack></attack></statistics>\n"
     let inputOriginal = inputOriginalPrefix <> inputOriginalSuffix
     let inputOriginalChunked = chunkedBy 16 inputOriginal
-    let inputOriginalBlanked = runListConduit blankXml inputOriginalChunked
+    let inputOriginalBlanked = blankXml inputOriginalChunked
 
     forAll (choose (0, 16)) $ \(n :: Int) -> do
       let inputShifted = inputOriginalPrefix <> repeatBS n " " <> inputOriginalSuffix
       let inputShiftedChunked = chunkedBy 16 inputShifted
-      let inputShiftedBlanked = runListConduit blankXml inputShiftedChunked
+      let inputShiftedBlanked = blankXml inputShiftedChunked
 
       -- putStrLn $ show (BS.concat inputShiftedBlanked) <> " vs " <> show (BS.concat inputOriginalBlanked)
       let actual    = Annotated (noSpaces (BS.concat inputShiftedBlanked )) (inputShiftedBlanked, n)
@@ -103,12 +102,12 @@ spec = describe "HaskellWorks.Data.Xml.Conduit.BlankSpec" $ do
     let inputOriginalSuffix = "<inner/></attack><attack></attack></statistics>\n"
     let inputOriginal = inputOriginalPrefix <> inputOriginalSuffix
     let inputOriginalChunked = chunkedBy 16 inputOriginal
-    let inputOriginalBlanked = runListConduit blankXml inputOriginalChunked
+    let inputOriginalBlanked = blankXml inputOriginalChunked
 
     let n = 15
     let inputShifted = inputOriginalPrefix <> repeatBS n " " <> inputOriginalSuffix
     let inputShiftedChunked = chunkedBy 16 inputShifted
-    let inputShiftedBlanked = runListConduit blankXml inputShiftedChunked
+    let inputShiftedBlanked = blankXml inputShiftedChunked
 
     -- putStrLn $ show (BS.concat inputShiftedBlanked) <> " vs " <> show (BS.concat inputOriginalBlanked)
     let actual    = Annotated (noSpaces (BS.concat inputShiftedBlanked )) (inputShiftedBlanked, n)

--- a/test/HaskellWorks/Data/Xml/Succinct/Cursor/BalancedParensSpec.hs
+++ b/test/HaskellWorks/Data/Xml/Succinct/Cursor/BalancedParensSpec.hs
@@ -3,12 +3,10 @@
 
 module HaskellWorks.Data.Xml.Succinct.Cursor.BalancedParensSpec(spec) where
 
-import Data.Conduit
 import Data.Monoid                                      ((<>))
 import Data.String
 import HaskellWorks.Data.Bits.BitShown
 import HaskellWorks.Data.ByteString
-import HaskellWorks.Data.Conduit.List
 import HaskellWorks.Data.Xml.Conduit
 import HaskellWorks.Data.Xml.Conduit.Blank
 import HaskellWorks.Data.Xml.Conduit.Blank
@@ -23,36 +21,36 @@ spec :: Spec
 spec = describe "HaskellWorks.Data.Xml.Succinct.Cursor.BalancedParensSpec" $ do
   it "Blanking XML should work 1" $ do
     let blankedXml = BlankedXml ["<t<t>>"]
-    let bp = BitShown $ BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) (getBlankedXml blankedXml))
+    let bp = BitShown $ BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 (getBlankedXml blankedXml)))
     bp `shouldBe` fromString "11011000"
   it "Blanking XML should work 2" $ do
     let blankedXml = BlankedXml
           [ "<><><><><><><><>"
           , "<><><><><><><><>"
           ]
-    let bp = BitShown $ BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) (getBlankedXml blankedXml))
+    let bp = BitShown $ BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 (getBlankedXml blankedXml)))
     bp `shouldBe` fromString
           "1010101010101010\
           \1010101010101010"
 
   let unchunkedInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<micro_stats>\n  <metric>\n  </metric>\n  <metric></metric>\n  <metric></metric>\n  <metric></metric>\n  <metric></metric>\n</micro_stats>\n"
   let chunkedInput = chunkedBy 15 unchunkedInput
-  let chunkedBlank = runListConduit blankXml chunkedInput
+  let chunkedBlank = blankXml chunkedInput
 
   let unchunkedBadInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<micro_stats>\n  <metric>       \n  </metric>\n  <metric></metric>\n  <metric></metric>\n  <metric></metric>\n  <metric></metric>\n</micro_stats>\n"
   let chunkedBadInput = chunkedBy 15 unchunkedBadInput
-  let chunkedBadBlank = runListConduit blankXml chunkedBadInput
+  let chunkedBadBlank = blankXml chunkedBadInput
 
   it "Same input" $ do
     unchunkedInput `shouldBe` BS.concat chunkedInput
 
   it "Blanking XML should work 3" $ do
-    let bp = BitShown $ BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) chunkedBlank)
+    let bp = BitShown $ BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 chunkedBlank))
     putStrLn $ "Good: " <> show chunkedBlank
     bp `shouldBe` fromString "11101010 10001101 01010100"
 
   it "Blanking XML should work 3" $ do
-    let bp = BitShown $ BS.concat (runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit) chunkedBadBlank)
+    let bp = BitShown $ BS.concat (compressWordAsBit (blankedXmlToBalancedParens2 chunkedBadBlank))
     putStrLn $ "Bad: " <> show chunkedBadBlank
     bp `shouldBe` fromString "11101010 10001101 01010100"
 
@@ -69,7 +67,7 @@ spec = describe "HaskellWorks.Data.Xml.Succinct.Cursor.BalancedParensSpec" $ do
 
 
 mkBlank :: Int -> BS.ByteString -> [BS.ByteString]
-mkBlank csize bs = runListConduit blankXml (chunkedBy csize bs)
+mkBlank csize bs = blankXml (chunkedBy csize bs)
 
 mkBits :: [BS.ByteString] -> [BS.ByteString]
-mkBits = runListConduit (blankedXmlToBalancedParens2 .| compressWordAsBit)
+mkBits = compressWordAsBit . blankedXmlToBalancedParens2

--- a/test/HaskellWorks/Data/Xml/Succinct/Cursor/InterestBitsSpec.hs
+++ b/test/HaskellWorks/Data/Xml/Succinct/Cursor/InterestBitsSpec.hs
@@ -7,7 +7,6 @@ import Data.Monoid                                        ((<>))
 import Data.String
 import Data.Word
 import HaskellWorks.Data.Bits.BitShown
-import HaskellWorks.Data.Conduit.List
 import HaskellWorks.Data.FromByteString
 import HaskellWorks.Data.Xml.Succinct.Cursor.BlankedXml
 import HaskellWorks.Data.Xml.Succinct.Cursor.InterestBits
@@ -47,7 +46,7 @@ spec = describe "HaskellWorks.Data.Xml.Succinct.Cursor.InterestBitsSpec" $ do
     let ib :: XmlInterestBits (BitShown (DVS.Vector Word8))
         ib = XmlInterestBits (getXmlInterestBits (fromBlankedXml (BlankedXml blanked)))
     let moo :: [BS.ByteString]
-        moo = runListConduit blankedXmlToInterestBits blanked -- :: XmlInterestBits (BitShown (DVS.Vector Word8))
+        moo = blankedXmlToInterestBits blanked -- :: XmlInterestBits (BitShown (DVS.Vector Word8))
     putStrLn $ "Moo:       " <> show (BitShown . BS.unpack <$> moo)
     let actual = getXmlInterestBits ib :: BitShown (DVS.Vector Word8)
     let expected = fromString "10000110 00000010 00001000 00000100 00000001 00100000 00000000"

--- a/test/HaskellWorks/Data/Xml/Succinct/CursorSpec.hs
+++ b/test/HaskellWorks/Data/Xml/Succinct/CursorSpec.hs
@@ -45,25 +45,6 @@ ss = TC.subtreeSize
 
 spec :: Spec
 spec = describe "HaskellWorks.Data.Xml.Succinct.CursorSpec" $ do
-  describe "Cursor for Element" $ do
-    it "depth at top" $ do
-      let cursor = "<widget debug='on'/>" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      cd cursor `shouldBe` Just 1
-    it "depth at attribute list" $ do
-      let cursor = "<widget debug='on' />" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> cd) cursor `shouldBe` Just 2
-    it "depth first attribute" $ do
-      let cursor = "<widget debug='on' enabled='on' />" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> fc >=> cd) cursor `shouldBe` Just 3
-    it "depth second attribute" $ do
-      let cursor = "<widget debug='on' enabled='on' />" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> fc >=> ns >=> cd) cursor `shouldBe` Just 3
-    it "depth at value" $ do
-      let cursor = "<widget debug='on'>text</widget>" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> ns >=> cd) cursor `shouldBe` Just 2
-    xit "depth at first child of object at second child of array" $ do
-      let cursor = "[null, {\"field\": 1}]" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> ns >=> fc >=> ns >=> cd) cursor `shouldBe` Just 3
   genSpec "DVS.Vector Word8"  (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word8)) (SimpleBalancedParens (DVS.Vector Word8)))
   genSpec "DVS.Vector Word16" (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word16)) (SimpleBalancedParens (DVS.Vector Word16)))
   genSpec "DVS.Vector Word32" (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word32)) (SimpleBalancedParens (DVS.Vector Word32)))
@@ -100,7 +81,6 @@ genSpec :: forall t u.
   , TestBit           u
   , FromForeignRegion (XmlCursor BS.ByteString t u)
   , IsString          (XmlCursor BS.ByteString t u)
-  , XmlIndexAt        (XmlCursor BS.ByteString t u)
   )
   => String -> XmlCursor BS.ByteString t u -> SpecWith ()
 genSpec t _ = do

--- a/test/HaskellWorks/Data/Xml/TypeSpec.hs
+++ b/test/HaskellWorks/Data/Xml/TypeSpec.hs
@@ -41,35 +41,7 @@ ns = TC.nextSibling
 
 spec :: Spec
 spec = describe "HaskellWorks.Data.Xml.TypeSpec" $ do
-  describe "Cursor for [Bool]" $ do
-    it "initialises to beginning of empty object" $ do
-      let cursor = "<elem />" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      xmlTypeAt cursor `shouldBe` Just XmlTypeElement
-    it "initialises to beginning of empty object preceded by spaces" $ do
-      let cursor = " <elem />" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      xmlTypeAt cursor `shouldBe` Just XmlTypeElement
-    it "cursor can navigate to attr list" $ do
-      let cursor = "<a foo='bar' boo='buzz'/>" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeAttrList
-    it "cursor can navigate through attrs" $ do
-      let cursor = "<a foo='bar' boo='buzz'/>" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> fc >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeToken --foo
-      (fc >=> fc >=> ns >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeToken --bar
-      (fc >=> fc >=> ns >=> ns >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeToken --boo
-      (fc >=> fc >=> ns >=> ns >=> ns >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeToken --buzz
-      (fc >=> fc >=> ns >=> ns >=> ns >=> ns >=> xmlTypeAt) cursor `shouldBe` Nothing --back off!
-    it "cursor can navigate to children" $ do
-      let cursor = "<a><b /><c /></a>" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeElement --b
-      (fc >=> ns >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeElement --c
-      (fc >=> ns >=> ns >=> xmlTypeAt) cursor `shouldBe` Nothing --back off!
-    it "cursor recognises child element as an element child next to attr list" $ do
-      let cursor = "<a foo='bar'><inner /></a>" :: XmlCursor String (BitShown [Bool]) (SimpleBalancedParens [Bool])
-      (fc >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeAttrList
-      (fc >=> ns >=> xmlTypeAt) cursor `shouldBe` Just XmlTypeElement
-      (fc >=> ns >=> ns >=> xmlTypeAt) cursor `shouldBe` Nothing -- no more!
-
-  genSpec "DVS.Vector Word8"  (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word8)) (SimpleBalancedParens (DVS.Vector Word8)))
+  genSpec "DVS.Vector Word8"  (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word8 )) (SimpleBalancedParens (DVS.Vector Word8 )))
   genSpec "DVS.Vector Word16" (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word16)) (SimpleBalancedParens (DVS.Vector Word16)))
   genSpec "DVS.Vector Word32" (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word32)) (SimpleBalancedParens (DVS.Vector Word32)))
   genSpec "DVS.Vector Word64" (undefined :: XmlCursor BS.ByteString (BitShown (DVS.Vector Word64)) (SimpleBalancedParens (DVS.Vector Word64)))


### PR DESCRIPTION
The library used conduits original because I was learning Haskell at the time.

I now think it's use is a pessimisation, so this PR removes it.