### PR TITLE
Remove bounds checking for table lookup

### DIFF
--- a/src/HaskellWorks/Data/Xml/Conduit.hs
+++ b/src/HaskellWorks/Data/Xml/Conduit.hs
@@ -11,9 +11,9 @@ module HaskellWorks.Data.Xml.Conduit
   ) where
 
 import Data.ByteString                as BS
-import Data.Vector.Storable           ((!))
 import Data.Word
 import Data.Word8
+import HaskellWorks.Data.AtIndex      ((!!!))
 import HaskellWorks.Data.Bits.BitWise
 import Prelude                        as P
 
@@ -38,7 +38,7 @@ interestingWord8s = DVS.constructN 256 go
 {-# NOINLINE interestingWord8s #-}
 
 isInterestingWord8 :: Word8 -> Word8
-isInterestingWord8 b = fromIntegral (interestingWord8s ! fromIntegral b)
+isInterestingWord8 b = fromIntegral (interestingWord8s !!! fromIntegral b)
 {-# INLINABLE isInterestingWord8 #-}
 
 blankedXmlToInterestBits :: [BS.ByteString] -> [BS.ByteString]
@@ -60,7 +60,7 @@ blankedXmlToInterestBits' rs is = case is of
   where gen :: ByteString -> Maybe (Word8, ByteString)
         gen as = if BS.length as == 0
           then Nothing
-          else Just ( BS.foldr' (\b m -> (interestingWord8s ! fromIntegral b) .|. (m .<. 1)) 0 (BS.take 8 as)
+          else Just ( BS.foldr' (\b m -> isInterestingWord8 b .|. (m .<. 1)) 0 (BS.take 8 as)
                     , BS.drop 8 as
                     )
 


### PR DESCRIPTION
Before

```
$ time hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx --bp-output psd7003.xml.bp.idx --method stream
hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx      31.22s user 3.83s system 219% cpu 15.978 total
$ time hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx --bp-output psd7003.xml.bp.idx --method stream
hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx      30.80s user 3.86s system 217% cpu 15.926 total
$ time hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx --bp-output psd7003.xml.bp.idx --method stream
hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx      30.12s user 3.68s system 213% cpu 15.812 total
```

After

```
$ time hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx --bp-output psd7003.xml.bp.idx --method stream
hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx      27.59s user 3.41s system 226% cpu 13.666 total
$ time hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx --bp-output psd7003.xml.bp.idx --method stream
hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx      27.46s user 3.57s system 224% cpu 13.799 total
$ time hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx --bp-output psd7003.xml.bp.idx --method stream
hw-xml create-index --input psd7003.xml --ib-output psd7003.xml.ib.idx      29.24s user 3.96s system 229% cpu 14.458 total
```